### PR TITLE
Add command line parameter -o to specify the file name of the snapshot 

### DIFF
--- a/src/deepinScrot.py
+++ b/src/deepinScrot.py
@@ -30,70 +30,125 @@ from utils import makeMenuItem, getFormatTime
 from constant import DEFAULT_FILENAME
 saveFiletype = "png"
 
-def saveToFile(fillscreen=True,fileName,fileType):
-    pixbuf = getScrotPixbuf(fullscreen)
-    pixbuf.save(fileName, fileType)
-    print "Save snapshot to %s" % (fileName)
+# def saveToFile(fillscreen=True,fileName,fileType):
+#     pixbuf = getScrotPixbuf(fullscreen)
+#     pixbuf.save(fileName, fileType)
+#     print "Save snapshot to %s" % (fileName)
 
-def openFileDialog(fullscreen=True, filetype='png'):
+def saveToFile(fullscreen=True, fileName=None):
     '''Save file to file.'''
     pixbuf = getScrotPixbuf(fullscreen)
-    dialog = gtk.FileChooserDialog(
-                                   "Save..",
-                                   None,
-                                   gtk.FILE_CHOOSER_ACTION_SAVE,
-                                   (gtk.STOCK_CANCEL, gtk.RESPONSE_REJECT,
-                                    gtk.STOCK_SAVE, gtk.RESPONSE_ACCEPT))
+
+    if fileName is None:
+        dialog = gtk.FileChooserDialog(
+                                       "Save..",
+                                       None,
+                                       gtk.FILE_CHOOSER_ACTION_SAVE,
+                                       (gtk.STOCK_CANCEL, gtk.RESPONSE_REJECT,
+                                        gtk.STOCK_SAVE, gtk.RESPONSE_ACCEPT))
+            
+        
+        dialog.set_default_response(gtk.RESPONSE_ACCEPT)
+        dialog.set_position(gtk.WIN_POS_CENTER)
+        dialog.set_local_only(True)
+        
+        dialog.set_current_folder(os.environ['HOME'])
+        dialog.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), saveFiletype))
+        
+        optionMenu = gtk.OptionMenu()
+        optionMenu.set_size_request(155, -1)
+        menu = gtk.Menu()
+        menu.set_size_request(155, -1)
+        
+        pngItem = makeMenuItem('PNG (*.png)',
+                     lambda item, data: setSaveFiletype(dialog, 'png'))
+        
+        jpgItem = makeMenuItem('JPEG (*.jpeg)',
+                     lambda item, data: setSaveFiletype(dialog, 'jpeg'))
+        
+        bmpItem = makeMenuItem('BMP (*.bmp)',
+                     lambda item, data: setSaveFiletype(dialog, 'bmp'))
+        
+        menu.append(pngItem)
+        menu.append(jpgItem)
+        menu.append(bmpItem)
+        optionMenu.set_menu(menu)
+        
+        hbox = gtk.HBox()
+        hbox.pack_end(optionMenu, False, False)
+        dialog.vbox.pack_start(hbox, False, False)
+        hbox.show_all()                          
+                
+        response = dialog.run()
+            
+        if response == gtk.RESPONSE_ACCEPT:
+            fileName = dialog.get_filename()
+        dialog.destroy()
+    if fileName is None:
+        print 'Closed, no files selected'
+    else:
+        pixbuf.save(fileName, saveFiletype)
+        print "Save snapshot to %s" % (fileName)
+    
+# def openFileDialog(fullscreen=True, filetype='png'):
+#     '''Save file to file.'''
+#     pixbuf = getScrotPixbuf(fullscreen)
+#     dialog = gtk.FileChooserDialog(
+#                                    "Save..",
+#                                    None,
+#                                    gtk.FILE_CHOOSER_ACTION_SAVE,
+#                                    (gtk.STOCK_CANCEL, gtk.RESPONSE_REJECT,
+#                                     gtk.STOCK_SAVE, gtk.RESPONSE_ACCEPT))
         
 
-    dialog.set_default_response(gtk.RESPONSE_ACCEPT)
-    dialog.set_position(gtk.WIN_POS_CENTER)
-    dialog.set_local_only(True)
+#     dialog.set_default_response(gtk.RESPONSE_ACCEPT)
+#     dialog.set_position(gtk.WIN_POS_CENTER)
+#     dialog.set_local_only(True)
         
     
-    dialog.set_current_folder(os.environ['HOME'])
-    dialog.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), saveFiletype))
+#     dialog.set_current_folder(os.environ['HOME'])
+#     dialog.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), saveFiletype))
 
        
         
 
-    optionMenu = gtk.OptionMenu()
-    optionMenu.set_size_request(155, -1)
-    menu = gtk.Menu()
-    menu.set_size_request(155, -1)
+#     optionMenu = gtk.OptionMenu()
+#     optionMenu.set_size_request(155, -1)
+#     menu = gtk.Menu()
+#     menu.set_size_request(155, -1)
     
-    pngItem = makeMenuItem('PNG (*.png)',
-                 lambda item, data: setSaveFiletype(dialog, 'png'))
+#     pngItem = makeMenuItem('PNG (*.png)',
+#                  lambda item, data: setSaveFiletype(dialog, 'png'))
     
-    jpgItem = makeMenuItem('JPEG (*.jpeg)',
-                 lambda item, data: setSaveFiletype(dialog, 'jpeg'))
+#     jpgItem = makeMenuItem('JPEG (*.jpeg)',
+#                  lambda item, data: setSaveFiletype(dialog, 'jpeg'))
     
-    bmpItem = makeMenuItem('BMP (*.bmp)',
-                 lambda item, data: setSaveFiletype(dialog, 'bmp'))
-    
-    
+#     bmpItem = makeMenuItem('BMP (*.bmp)',
+#                  lambda item, data: setSaveFiletype(dialog, 'bmp'))
     
     
-    menu.append(pngItem)
-    menu.append(jpgItem)
-    menu.append(bmpItem)
-    optionMenu.set_menu(menu)
     
     
-    hbox = gtk.HBox()
-    hbox.pack_end(optionMenu, False, False)
-    dialog.vbox.pack_start(hbox, False, False)
-    hbox.show_all()                          
+#     menu.append(pngItem)
+#     menu.append(jpgItem)
+#     menu.append(bmpItem)
+#     optionMenu.set_menu(menu)
+    
+    
+#     hbox = gtk.HBox()
+#     hbox.pack_end(optionMenu, False, False)
+#     dialog.vbox.pack_start(hbox, False, False)
+#     hbox.show_all()                          
             
-    response = dialog.run()
+#     response = dialog.run()
         
-    if response == gtk.RESPONSE_ACCEPT:
-        filename = dialog.get_filename()
-        pixbuf.save(filename, filetype)
-        print "Save snapshot to %s" % (filename)
-    elif response == gtk.RESPONSE_REJECT:
-        print 'Closed, no files selected'
-    dialog.destroy()
+#     if response == gtk.RESPONSE_ACCEPT:
+#         filename = dialog.get_filename()
+#         pixbuf.save(filename, filetype)
+#         print "Save snapshot to %s" % (filename)
+#     elif response == gtk.RESPONSE_REJECT:
+#         print 'Closed, no files selected'
+#     dialog.destroy()
 
 def setSaveFiletype(widget, filetype):
     widget.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), filetype))
@@ -129,35 +184,31 @@ def processArguments():
     parser.add_option("-o", "--outfile", dest="outfile", type="str", help="Save the snapshot to a file, file type png,jepg and bmp are supported")    
     (options, args) = parser.parse_args()
     #print parser.parse_args()
+    (fileName,saveFileType) = (None,"png")
+    if options.outfile:
+        (fileName,saveFileType) = getFileNameFileType(options.outfile)
+        if fileName is None:
+            sys.exit(-1)
     if options.fullscreen and options.window:
         parser.error("options -f and -w are mutually exclusive")
     elif options.fullscreen:
         if options.delay:
             countdownWindow(options.delay)
-            openFileDialog()
+            saveToFile(True,fileName)
+#            openFileDialog()
         else:
-            openFileDialog()
+            saveToFile(True,fileName)
     elif options.window:
         if options.delay:
             countdownWindow(options.delay)
-            openFileDialog(False)
+            saveToFile(False,fileName)
         else:
-            openFileDialog(False)
+            saveToFile(False,fileName)
     elif options.fullscreen and options.window or options.delay:
         countdownWindow(options.delay)
-        if options.outfile:
-            (fileName,fileType) = getFileNameFileType(options.outfile)
-            if fileName:
-                MainScrot(fileName,fileType)
-        else:
-            MainScrot()
+        MainScrot(fileName,saveFileType)
     else:
-        if options.outfile:
-            (fileName,fileType) = getFileNameFileType(options.outfile)
-            if fileName:
-                MainScrot(fileName,fileType)
-        else:
-            MainScrot()
+        MainScrot(fileName,saveFileType)
         
         
 

--- a/src/deepinScrot.py
+++ b/src/deepinScrot.py
@@ -30,10 +30,6 @@ from utils import makeMenuItem, getFormatTime
 from constant import DEFAULT_FILENAME
 saveFiletype = "png"
 
-# def saveToFile(fillscreen=True,fileName,fileType):
-#     pixbuf = getScrotPixbuf(fullscreen)
-#     pixbuf.save(fileName, fileType)
-#     print "Save snapshot to %s" % (fileName)
 
 def saveToFile(fullscreen=True, fileName=None):
     '''Save file to file.'''
@@ -90,65 +86,6 @@ def saveToFile(fullscreen=True, fileName=None):
         pixbuf.save(fileName, saveFiletype)
         print "Save snapshot to %s" % (fileName)
     
-# def openFileDialog(fullscreen=True, filetype='png'):
-#     '''Save file to file.'''
-#     pixbuf = getScrotPixbuf(fullscreen)
-#     dialog = gtk.FileChooserDialog(
-#                                    "Save..",
-#                                    None,
-#                                    gtk.FILE_CHOOSER_ACTION_SAVE,
-#                                    (gtk.STOCK_CANCEL, gtk.RESPONSE_REJECT,
-#                                     gtk.STOCK_SAVE, gtk.RESPONSE_ACCEPT))
-        
-
-#     dialog.set_default_response(gtk.RESPONSE_ACCEPT)
-#     dialog.set_position(gtk.WIN_POS_CENTER)
-#     dialog.set_local_only(True)
-        
-    
-#     dialog.set_current_folder(os.environ['HOME'])
-#     dialog.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), saveFiletype))
-
-       
-        
-
-#     optionMenu = gtk.OptionMenu()
-#     optionMenu.set_size_request(155, -1)
-#     menu = gtk.Menu()
-#     menu.set_size_request(155, -1)
-    
-#     pngItem = makeMenuItem('PNG (*.png)',
-#                  lambda item, data: setSaveFiletype(dialog, 'png'))
-    
-#     jpgItem = makeMenuItem('JPEG (*.jpeg)',
-#                  lambda item, data: setSaveFiletype(dialog, 'jpeg'))
-    
-#     bmpItem = makeMenuItem('BMP (*.bmp)',
-#                  lambda item, data: setSaveFiletype(dialog, 'bmp'))
-    
-    
-    
-    
-#     menu.append(pngItem)
-#     menu.append(jpgItem)
-#     menu.append(bmpItem)
-#     optionMenu.set_menu(menu)
-    
-    
-#     hbox = gtk.HBox()
-#     hbox.pack_end(optionMenu, False, False)
-#     dialog.vbox.pack_start(hbox, False, False)
-#     hbox.show_all()                          
-            
-#     response = dialog.run()
-        
-#     if response == gtk.RESPONSE_ACCEPT:
-#         filename = dialog.get_filename()
-#         pixbuf.save(filename, filetype)
-#         print "Save snapshot to %s" % (filename)
-#     elif response == gtk.RESPONSE_REJECT:
-#         print 'Closed, no files selected'
-#     dialog.destroy()
 
 def setSaveFiletype(widget, filetype):
     widget.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), filetype))

--- a/src/deepinScrot.py
+++ b/src/deepinScrot.py
@@ -30,6 +30,11 @@ from utils import makeMenuItem, getFormatTime
 from constant import DEFAULT_FILENAME
 saveFiletype = "png"
 
+def saveToFile(fillscreen=True,fileName,fileType):
+    pixbuf = getScrotPixbuf(fullscreen)
+    pixbuf.save(fileName, fileType)
+    print "Save snapshot to %s" % (fileName)
+
 def openFileDialog(fullscreen=True, filetype='png'):
     '''Save file to file.'''
     pixbuf = getScrotPixbuf(fullscreen)
@@ -93,7 +98,27 @@ def openFileDialog(fullscreen=True, filetype='png'):
 def setSaveFiletype(widget, filetype):
     widget.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), filetype))
     saveFiletype =filetype
-       
+
+def getFileNameFileType(fileName):
+    basename = os.path.basename(fileName).split(".")
+    if len(basename)>1:
+        fileType = basename[-1]
+    else:
+        fileType = None
+    if fileType.lower() in ("png","jepg","bmp"):
+        fileName = os.path.expanduser(fileName)
+        fileName = os.path.abspath(fileName)
+        dirName = os.path.dirname(fileName)
+        if os.path.isdir(dirName):
+            return (fileName,fileType)
+        else:
+            print dirName,"do not exist or not a directory"
+            return (None,None)
+    else:
+        print "The only supported file types are png, jepg and bmp"
+        return (None,None)
+        
+    
 
 def processArguments():
     '''init processArguments '''
@@ -101,7 +126,7 @@ def processArguments():
     parser.add_option("-f", "--full", action="store_true", dest="fullscreen", help="Taking the fullscreen shot")
     parser.add_option("-w", "--window", action="store_true", dest="window", help="Taking the currently focused window")
     parser.add_option("-d", "--delay", dest="delay", type="int", help="wait NUM seconds before taking a shot", metavar="NUM")
-    
+    parser.add_option("-o", "--outfile", dest="outfile", type="str", help="Save the snapshot to a file, file type png,jepg and bmp are supported")    
     (options, args) = parser.parse_args()
     #print parser.parse_args()
     if options.fullscreen and options.window:
@@ -120,9 +145,19 @@ def processArguments():
             openFileDialog(False)
     elif options.fullscreen and options.window or options.delay:
         countdownWindow(options.delay)
-        MainScrot()
+        if options.outfile:
+            (fileName,fileType) = getFileNameFileType(options.outfile)
+            if fileName:
+                MainScrot(fileName,fileType)
+        else:
+            MainScrot()
     else:
-         MainScrot()
+        if options.outfile:
+            (fileName,fileType) = getFileNameFileType(options.outfile)
+            if fileName:
+                MainScrot(fileName,fileType)
+        else:
+            MainScrot()
         
         
 

--- a/src/mainscrot.py
+++ b/src/mainscrot.py
@@ -51,6 +51,9 @@ class MainScrot:
     def __init__(self,saveFileName=None, saveFiletype="png"):
         '''Init Main scrot.'''
 
+        # The file that saves the path of last saved file
+        self.dataFileName = os.path.expanduser("~/.deepin-scrot.tmp")
+        
         # Init.
         self.action = ACTION_WINDOW
         self.width = self.height = 0
@@ -1024,7 +1027,7 @@ class MainScrot:
         dialog.set_default_response(gtk.RESPONSE_ACCEPT)
         dialog.set_position(gtk.WIN_POS_MOUSE)
         dialog.set_local_only(True)
-        dialog.set_current_folder(os.environ['HOME'])
+        dialog.set_current_folder(self.getDefaultTargetPath())
         dialog.set_current_name("%s%s.%s" % (DEFAULT_FILENAME, getFormatTime(), self.saveFiletype))
         
         optionMenu = gtk.OptionMenu()
@@ -1064,6 +1067,7 @@ class MainScrot:
         if response == gtk.RESPONSE_ACCEPT:
             filename = dialog.get_filename()
             self.saveSnapshot(filename, self.saveFiletype)
+            self.setDefaultTargetPath(os.path.dirname(filename))
             print "Save snapshot to %s" % (filename)
         elif response == gtk.RESPONSE_REJECT:
             self.adjustToolbar()
@@ -1074,6 +1078,23 @@ class MainScrot:
             print 'Closed, no files selected'
         dialog.destroy()
 
+    def setDefaultTargetPath(self,path):
+        with open(self.dataFileName,"w") as fd:
+            fd.write(path)
+
+    def getDefaultTargetPath(self,):
+        try:
+            with open(self.dataFileName) as fd:
+                defaultPath = fd.readline()
+        except IOError:
+            return os.environ['HOME']
+        if os.path.isdir(defaultPath):
+            return defaultPath
+        else:
+            return os.environ['HOME']
+                
+
+            
         
     def setSaveFiletype(self, dialog, filetype):
         ''' save filetype '''

--- a/src/mainscrot.py
+++ b/src/mainscrot.py
@@ -48,7 +48,7 @@ pygtk.require('2.0')
 class MainScrot:
     '''Main scrot.'''
 	
-    def __init__(self):
+    def __init__(self,saveFileName=None, saveFiletype="png"):
         '''Init Main scrot.'''
 
         # Init.
@@ -68,7 +68,8 @@ class MainScrot:
         self.showColorbarFlag = False 
         self.showTextWindowFlag = False
         self.textDragOffsetX = self.textDragOffsetY = 0
-        self.saveFiletype = 'png'
+        self.saveFileName = saveFileName
+        self.saveFiletype = saveFiletype
         
         self.toolbarOffsetX = 10
         self.toolbarOffsetY = 10
@@ -436,7 +437,7 @@ class MainScrot:
         self.actionCancelButton.connect("button-press-event", lambda w, e: self.destroy(self.window))
 
         self.actionFinishButton = self.createOtherButton("finish",__("Tip finish"))
-        self.actionFinishButton.connect("button-press-event", lambda w, e: self.saveSnapshot())
+        self.actionFinishButton.connect("button-press-event", lambda w, e: self.saveSnapshot(self.saveFileName,self.saveFiletype))
       
       
     def setOtherInactive(self, button):
@@ -991,7 +992,7 @@ class MainScrot:
             self.textModifyFlag = True
        
         if isDoubleClick(event) and self.action == ACTION_SELECT and self.x < ex < self.x + self.rectWidth and self.y < ey < self.y + self.rectHeight:
-            self.saveSnapshot()
+            self.saveSnapshot(self.saveFileName,self.saveFiletype)
             self.buttonRelease(widget, event)
          
 


### PR DESCRIPTION
I'm trying to use deepin-scrot instead of scrot to capture screen in emacs, which require the screen capture program can specify the output file name from command line.
I modified deepin-scrot a little bit, adding a -o option to specify the output file name. If -o is used, it will save the snapshot to the file specified by -o when click finish button. If -o option is not used, the behaver will be the same (save to clipboard)
Please accept this pull request if you like the change and any comments are welcomed

Cheers!
